### PR TITLE
test: use "assertGe" instead of "assertTrue"

### DIFF
--- a/test/InvariantExampleTests.t.sol
+++ b/test/InvariantExampleTests.t.sol
@@ -51,12 +51,12 @@ contract Basic4626InvariantBase is DSTest, InvariantTest {
 
             uint256 assetBalance = token.convertToAssets(token.balanceOf(lp));
 
-            assertTrue(assetBalance >= token.balanceOf(lp));
+            assertGe(assetBalance, token.balanceOf(lp));
 
             sumAssets += assetBalance;
         }
 
-        assertTrue((token.totalAssets() - sumAssets) <= numLps);
+        assertLe(token.totalAssets() - sumAssets, numLps);
     }
 
 }


### PR DESCRIPTION
I find it more idiomatic to use `assertGe` instead of `assertTrue` in this repo, because many invariants are comparative in nature. I argue we should nudge users towards using these comparison assertions.